### PR TITLE
Improve the Windows wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ The intention of the scripts in this repo is to provide a comaptible and safe wa
 This is how to call the linux wrapper script from bash without having to store a copy locally:
 ```bash
 # Without arguments
-curl -s https://raw.githubusercontent.com/dsb-norge/terraform-tflint-wrappers/main/tflint_linux.sh \
-| bash -s --
+curl -s https://raw.githubusercontent.com/dsb-norge/terraform-tflint-wrappers/main/tflint_linux.sh |
+  bash -s --
 
 # With arguments
-curl -s https://raw.githubusercontent.com/dsb-norge/terraform-tflint-wrappers/main/tflint_linux.sh \
-| bash -s -- --uninstall
+curl -s https://raw.githubusercontent.com/dsb-norge/terraform-tflint-wrappers/main/tflint_linux.sh |
+  bash -s -- --uninstall
 ```
 
 ### Powershell
@@ -28,7 +28,7 @@ Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://raw
 # With arguments
 Invoke-Command `
   -ScriptBlock ([scriptblock]::Create(((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/dsb-norge/terraform-tflint-wrappers/main/tflint_windows.ps1')) -join "`n")) `
-  -ArgumentList $false,$true # Force = false, Remove = true
+  -ArgumentList $false,$true,$false # Force = false, Remove = true, ExitWithCode = false
 ```
 
 ## Development
@@ -52,5 +52,5 @@ Invoke-Expression ([String]::Join("`n",(Get-Content '.\tflint_windows.ps1')))
 # With arguments
 Invoke-Command `
   -ScriptBlock ([scriptblock]::Create((Get-Content '.\tflint_windows.ps1') -join "`n")) `
-  -ArgumentList $false,$true # Force = false, Remove = true
+  -ArgumentList $false,$true,$false # Force = false, Remove = true, ExitWithCode = false
 ```

--- a/tflint_windows.ps1
+++ b/tflint_windows.ps1
@@ -180,7 +180,13 @@ if ( (Invoke-Command $_terraformModulesJsonExists) )
 # Look for *.tfvars files
 $tfvarsFiles = Get-ChildItem -Path $scriptDir -Filter '*.tfvars' -File
 $lintingResults = @{}
-if ( $tfvarsFiles )
+if ( -not $tfvarsFiles )
+{
+    # $lintingResults will be hashtable with one key
+    Write-Debug "No .tfvars files found in $scriptDir"
+    $lintingResults += @{ '' = @{} }
+}
+else
 {
     # $lintingResults will be hashtable with each tfvars file as key
     $tfvarsFiles | ForEach-Object { $lintingResults += @{ $_.Name = @{} } }
@@ -195,7 +201,7 @@ foreach ($lintDir in $directoriesToLint)
     {
         # Invoke without '/var-file'
         & "$tflintBinPath" /config:"$tflintConfigFile" "$lintDir" 2>&1
-        $lintingResults += @{ '' = @{ $lintDir = $LASTEXITCODE } }
+        $lintingResults[''] += @{ $lintDir = $LASTEXITCODE }
     }
     else # tfvars exists, iterate over them
     {

--- a/tflint_windows.ps1
+++ b/tflint_windows.ps1
@@ -174,11 +174,11 @@ if ( (Invoke-Command $_terraformModulesJsonExists) )
                 $_
             }
         }
-    )
+    ) | Sort-Object
 }
 
 # Look for *.tfvars files
-$tfvarsFiles = Get-ChildItem -Path $scriptDir -Filter '*.tfvars' -File
+$tfvarsFiles = Get-ChildItem -Path $scriptDir -Filter '*.tfvars' -File | Sort-Object
 $lintingResults = @{}
 if ( -not $tfvarsFiles )
 {
@@ -215,9 +215,9 @@ foreach ($lintDir in $directoriesToLint)
 
 # Summarize results of linting
 Write-Host "`n`nTFLint summary:`n$separatorShort"
-foreach ($varFile in $lintingResults.Keys)
+foreach ($varFile in ($lintingResults.Keys | Sort-Object) )
 {
-    foreach ($lintDir in $lintingResults."$varFile".Keys)
+    foreach ($lintDir in ($lintingResults."$varFile".Keys | Sort-Object) )
     {
         Write-Host $(if ($lintingResults."$varFile"."$lintDir" -ne 0)
             {


### PR DESCRIPTION
# New features
- Windows wrapper: Return instead of exit:
    - Changed behavior: Default is to return the exit code instead of terminating the powershell process. Previous behavior with powershell termination can be achieved with tthe flag `-ExitWithCode`.
- Added debug output.

# Improvements
- Sort output and processing.

# Fixes
- Linting i projects without .tfvars files.